### PR TITLE
Fix: Minify Strings Always On

### DIFF
--- a/modules/misc/chat.lua
+++ b/modules/misc/chat.lua
@@ -297,7 +297,10 @@ end
     @ return void
 ]]
 function ImpUI_Chat:OnEnable()
-    ImpUI_Chat:OverrideStrings();
+    local minify = ImpUI.db.char.minifyStrings;
+    if (minify == true) then
+        ImpUI_Chat:OverrideStrings();    
+    end
     ImpUI_Chat:StyleChat();
 
     -- Apply Quality of Life changes that don't need to be toggled.


### PR DESCRIPTION
Following the fix in [this fix](https://github.com/kaytotes/ImprovedBlizzardUI/pull/143) for the retail version. Tested it in game and it appears to work consistently. Fixes #3. 