### PR TITLE
Added profiles for sharing settings accross characters.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/settings.json
 .vscode/launch.json
+/.vs

--- a/config.lua
+++ b/config.lua
@@ -7,7 +7,7 @@ ImpUI_Config = {};
 	Defaults for every new character.
 ]]
 ImpUI_Config.defaults = {
-    char = {
+    profile = {
         primaryInterfaceFont = 'Improved Blizzard UI',
         afkMode = true,
         autoRepair = true,
@@ -124,10 +124,10 @@ ImpUI_Config.options = {
                     name = L['Style Unit Frames'],
                     desc = L['Applies modified textures and font styling to the Player, Target and Party Frames. This will trigger a UI Reload!'],
                     get = function ()
-                        return ImpUI.db.char.styleUnitFrames;
+                        return ImpUI.db.profile.styleUnitFrames;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.styleUnitFrames = newValue;
+                        ImpUI.db.profile.styleUnitFrames = newValue;
                         ReloadUI();
                     end,
                     order = 1,
@@ -145,10 +145,10 @@ ImpUI_Config.options = {
                     name = L['Display Class Colours'],
                     desc = '',
                     get = function ()
-                        return ImpUI.db.char.playerClassColours;
+                        return ImpUI.db.profile.playerClassColours;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.playerClassColours = newValue;
+                        ImpUI.db.profile.playerClassColours = newValue;
                         ImpUI_Player:ToggleClassColours(newValue);
                     end,
                     order = 3,
@@ -159,10 +159,10 @@ ImpUI_Config.options = {
                     name = L['Hide Portrait Spam'],
                     desc = L['Hides the damage text that appears over the Player portrait when damaged or healed.'],
                     get = function ()
-                        return ImpUI.db.char.playerHidePortraitSpam;
+                        return ImpUI.db.profile.playerHidePortraitSpam;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.playerHidePortraitSpam = newValue;
+                        ImpUI.db.profile.playerHidePortraitSpam = newValue;
                     end,
                     order = 4,
                 },
@@ -172,10 +172,10 @@ ImpUI_Config.options = {
                     name = L['Hide Out of Combat'],
                     desc = L['Hides the Player Frame when you are out of combat, have no target and are at full health.'],
                     get = function ()
-                        return ImpUI.db.char.playerHideOOC;
+                        return ImpUI.db.profile.playerHideOOC;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.playerHideOOC = newValue;
+                        ImpUI.db.profile.playerHideOOC = newValue;
 
                         ImpUI_Player:TogglePlayer(newValue);
                     end,
@@ -190,10 +190,10 @@ ImpUI_Config.options = {
                     max = 4.0,
                     step = 0.1,
                     get = function ()
-                        return ImpUI.db.char.playerFrameScale;
+                        return ImpUI.db.profile.playerFrameScale;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.playerFrameScale = newValue; 
+                        ImpUI.db.profile.playerFrameScale = newValue; 
 
                         ImpUI_Player:LoadPosition();
                     end,
@@ -213,10 +213,10 @@ ImpUI_Config.options = {
                     name = L['Display Class Colours'],
                     desc = '',
                     get = function ()
-                        return ImpUI.db.char.targetClassColours;
+                        return ImpUI.db.profile.targetClassColours;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.targetClassColours = newValue;
+                        ImpUI.db.profile.targetClassColours = newValue;
                         TargetFrame:Hide();
                     end,
                     order = 8,
@@ -227,10 +227,10 @@ ImpUI_Config.options = {
                     name = L['Buffs On Top'],
                     desc = L['Displays the Targets Buffs above the Unit Frame.'],
                     get = function ()
-                        return ImpUI.db.char.targetBuffsOnTop;
+                        return ImpUI.db.profile.targetBuffsOnTop;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.targetBuffsOnTop = newValue;
+                        ImpUI.db.profile.targetBuffsOnTop = newValue;
                         TargetFrame:Hide();
                     end,
                     order = 9,
@@ -241,10 +241,10 @@ ImpUI_Config.options = {
                     name = L['ToT Class Colours'],
                     desc = L['Colours Target of Target Health bar to match their class.'],
                     get = function ()
-                        return ImpUI.db.char.targetOfTargetClassColours;
+                        return ImpUI.db.profile.targetOfTargetClassColours;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.targetOfTargetClassColours = newValue;
+                        ImpUI.db.profile.targetOfTargetClassColours = newValue;
                         TargetFrame:Hide();
                     end,
                     order = 10,
@@ -258,10 +258,10 @@ ImpUI_Config.options = {
                     max = 4.0,
                     step = 0.1,
                     get = function ()
-                        return ImpUI.db.char.targetFrameScale;
+                        return ImpUI.db.profile.targetFrameScale;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.targetFrameScale = newValue; 
+                        ImpUI.db.profile.targetFrameScale = newValue; 
 
                         ImpUI_Target:LoadPosition();
                     end,
@@ -284,10 +284,10 @@ ImpUI_Config.options = {
                     max = 4.0,
                     step = 0.1,
                     get = function ()
-                        return ImpUI.db.char.partyFrameScale;
+                        return ImpUI.db.profile.partyFrameScale;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.partyFrameScale = newValue; 
+                        ImpUI.db.profile.partyFrameScale = newValue; 
 
                         ImpUI_Party:LoadPosition();
                     end,
@@ -319,10 +319,10 @@ ImpUI_Config.options = {
                     max = 4.0,
                     step = 0.1,
                     get = function ()
-                        return ImpUI.db.char.castBarScale;
+                        return ImpUI.db.profile.castBarScale;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.castBarScale = newValue; 
+                        ImpUI.db.profile.castBarScale = newValue; 
 
                         ImpUI_CastBar:LoadPosition();
                     end,
@@ -338,10 +338,10 @@ ImpUI_Config.options = {
                     max = 32,
                     step = 1,
                     get = function ()
-                        return ImpUI.db.char.castBarFontSize;
+                        return ImpUI.db.profile.castBarFontSize;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.castBarFontSize = newValue; 
+                        ImpUI.db.profile.castBarFontSize = newValue; 
 
                         ImpUI_CastBar:StyleFrame();
                     end,
@@ -354,10 +354,10 @@ ImpUI_Config.options = {
                     name = L['Player Cast Timer'],
                     desc = L['Displays a Timer on the Players Cast Bar.'],
                     get = function ()
-                        return ImpUI.db.char.castBarPlayerTimer;
+                        return ImpUI.db.profile.castBarPlayerTimer;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.castBarPlayerTimer = newValue;
+                        ImpUI.db.profile.castBarPlayerTimer = newValue;
 
                         ImpUI_CastBar:StyleFrame();
                     end,
@@ -379,10 +379,10 @@ ImpUI_Config.options = {
                     max = 4.0,
                     step = 0.1,
                     get = function ()
-                        return ImpUI.db.char.buffsScale;
+                        return ImpUI.db.profile.buffsScale;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.buffsScale = newValue; 
+                        ImpUI.db.profile.buffsScale = newValue; 
 
                         ImpUI_Buffs:LoadPosition();
                     end,
@@ -404,10 +404,10 @@ ImpUI_Config.options = {
                     name = L['Anchor To Mouse'],
                     desc = L['The tooltip will always display at the mouse location.'],
                     get = function ()
-                        return ImpUI.db.char.anchorMouse;
+                        return ImpUI.db.profile.anchorMouse;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.anchorMouse = newValue;
+                        ImpUI.db.profile.anchorMouse = newValue;
                     end,
                     order = 1,
                 },
@@ -417,10 +417,10 @@ ImpUI_Config.options = {
                     name = L['Style Tooltips'],
                     desc = L['Adjusts the information and style of the default tooltips.'],
                     get = function ()
-                        return ImpUI.db.char.styleTooltips;
+                        return ImpUI.db.profile.styleTooltips;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.styleTooltips = newValue;
+                        ImpUI.db.profile.styleTooltips = newValue;
                         ImpUI_Tooltips:ResetStyle();
                     end,
                     order = 2,
@@ -431,13 +431,13 @@ ImpUI_Config.options = {
                     name = L['Guild Colour'],
                     desc = L['The colour of the guild name display in tooltips.'],
                     get = function ()
-                        return Helpers.colour_unpack(ImpUI.db.char.tooltipGuildColour);
+                        return Helpers.colour_unpack(ImpUI.db.profile.tooltipGuildColour);
                     end,
                     set = function (_, r, g, b, a)
-                        ImpUI.db.char.tooltipGuildColour = Helpers.colour_pack(r, g, b, a);
+                        ImpUI.db.profile.tooltipGuildColour = Helpers.colour_pack(r, g, b, a);
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.styleTooltips == false;
+                        return ImpUI.db.profile.styleTooltips == false;
                     end,
                     hasAlpha = false,
                     order = 3,
@@ -448,13 +448,13 @@ ImpUI_Config.options = {
                     name = L['Hostile Border'],
                     desc = L['Colours the border of the tooltip based on the hostility of the target.'],
                     get = function ()
-                        return ImpUI.db.char.tooltipHostileBorder;
+                        return ImpUI.db.profile.tooltipHostileBorder;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.tooltipHostileBorder = newValue;
+                        ImpUI.db.profile.tooltipHostileBorder = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.styleTooltips == false;
+                        return ImpUI.db.profile.styleTooltips == false;
                     end,
                     order = 4,
                 },
@@ -464,13 +464,13 @@ ImpUI_Config.options = {
                     name = L['Class Coloured Name'],
                     desc = L['Colours the name of the target to match their Class.'],
                     get = function ()
-                        return ImpUI.db.char.tooltipNameClassColours;
+                        return ImpUI.db.profile.tooltipNameClassColours;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.tooltipNameClassColours = newValue;
+                        ImpUI.db.profile.tooltipNameClassColours = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.styleTooltips == false;
+                        return ImpUI.db.profile.styleTooltips == false;
                     end,
                     order = 5,
                 },
@@ -480,13 +480,13 @@ ImpUI_Config.options = {
                     name = L['Show Target of Target'],
                     desc = L['Displays who / what the unit is targeting. Coloured by Class.'],
                     get = function ()
-                        return ImpUI.db.char.tooltipToT;
+                        return ImpUI.db.profile.tooltipToT;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.tooltipToT = newValue;
+                        ImpUI.db.profile.tooltipToT = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.styleTooltips == false;
+                        return ImpUI.db.profile.styleTooltips == false;
                     end,
                     order = 6,
                 },
@@ -496,13 +496,13 @@ ImpUI_Config.options = {
                     name = L['Class Colour Health Bar'],
                     desc = L['Colours the Tooltip Health Bar by Class.'],
                     get = function ()
-                        return ImpUI.db.char.tooltipHealthClassColours;
+                        return ImpUI.db.profile.tooltipHealthClassColours;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.tooltipHealthClassColours = newValue;
+                        ImpUI.db.profile.tooltipHealthClassColours = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.styleTooltips == false;
+                        return ImpUI.db.profile.styleTooltips == false;
                     end,
                     order = 6,
                 },
@@ -512,13 +512,13 @@ ImpUI_Config.options = {
                     name = L['Item Rarity Border'],
                     desc = L['Colours the tooltip border by the rarity of the item you are inspecting.'],
                     get = function ()
-                        return ImpUI.db.char.tooltipItemRarity;
+                        return ImpUI.db.profile.tooltipItemRarity;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.tooltipItemRarity = newValue;
+                        ImpUI.db.profile.tooltipItemRarity = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.styleTooltips == false;
+                        return ImpUI.db.profile.styleTooltips == false;
                     end,
                     order = 7,
                 },
@@ -544,10 +544,10 @@ ImpUI_Config.options = {
                     name = L['Health Warnings'],
                     desc = L['Displays a five second warning when Player Health is less than 50% and 25%.'],
                     get = function ()
-                        return ImpUI.db.char.healthWarnings;
+                        return ImpUI.db.profile.healthWarnings;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.healthWarnings = newValue;
+                        ImpUI.db.profile.healthWarnings = newValue;
                     end,
                     order = 2,
                 },
@@ -557,13 +557,13 @@ ImpUI_Config.options = {
                     name = L['50% Colour'],
                     desc = L['The colour of the warning that displays at 50% health.'],
                     get = function ()
-                        return Helpers.colour_unpack(ImpUI.db.char.healthWarningHalfColour);
+                        return Helpers.colour_unpack(ImpUI.db.profile.healthWarningHalfColour);
                     end,
                     set = function (_, r, g, b, a)
-                        ImpUI.db.char.healthWarningHalfColour = Helpers.colour_pack(r, g, b, a);
+                        ImpUI.db.profile.healthWarningHalfColour = Helpers.colour_pack(r, g, b, a);
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.healthWarnings == false;
+                        return ImpUI.db.profile.healthWarnings == false;
                     end,
                     hasAlpha = false,
                     order = 3,
@@ -574,13 +574,13 @@ ImpUI_Config.options = {
                     name = L['25% Colour'],
                     desc = L['The colour of the warning that displays at 25% health.'],
                     get = function ()
-                        return Helpers.colour_unpack(ImpUI.db.char.healthWarningQuarterColour);
+                        return Helpers.colour_unpack(ImpUI.db.profile.healthWarningQuarterColour);
                     end,
                     set = function (_, r, g, b, a)
-                        ImpUI.db.char.healthWarningQuarterColour = Helpers.colour_pack(r, g, b, a);
+                        ImpUI.db.profile.healthWarningQuarterColour = Helpers.colour_pack(r, g, b, a);
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.healthWarnings == false;
+                        return ImpUI.db.profile.healthWarnings == false;
                     end,
                     hasAlpha = false,
                     order = 4,
@@ -594,13 +594,13 @@ ImpUI_Config.options = {
                     max = 104,
                     step = 1,
                     get = function ()
-                        return ImpUI.db.char.healthWarningSize;
+                        return ImpUI.db.profile.healthWarningSize;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.healthWarningSize = newValue; 
+                        ImpUI.db.profile.healthWarningSize = newValue; 
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.healthWarnings == false;
+                        return ImpUI.db.profile.healthWarnings == false;
                     end,
                     isPercent = false,
                     order = 5,
@@ -613,13 +613,13 @@ ImpUI_Config.options = {
                     dialogControl = 'LSM30_Font',
                     values = LSM:HashTable( LSM.MediaType.FONT ),
                     get = function ()
-                        return ImpUI.db.char.healthWarningFont;
+                        return ImpUI.db.profile.healthWarningFont;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.healthWarningFont = newValue; 
+                        ImpUI.db.profile.healthWarningFont = newValue; 
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.healthWarnings == false;
+                        return ImpUI.db.profile.healthWarnings == false;
                     end,
                     order = 6,
                 },
@@ -636,10 +636,10 @@ ImpUI_Config.options = {
                     name = L['Announce Interrupts'],
                     desc = L['When you interrupt a target your character announces this to an appropriate sound channel.'],
                     get = function ()
-                        return ImpUI.db.char.announceInterrupts;
+                        return ImpUI.db.profile.announceInterrupts;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.announceInterrupts = newValue; 
+                        ImpUI.db.profile.announceInterrupts = newValue; 
                     end,
                     order = 8,
                 },
@@ -649,10 +649,10 @@ ImpUI_Config.options = {
                     name = L['Chat Channel'],
                     desc = L['The Channel that should be used when announcing an interrupt. Auto intelligently chooses based on situation.'],
                     get = function ()
-                        return ImpUI.db.char.interruptChannel;
+                        return ImpUI.db.profile.interruptChannel;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.interruptChannel = newValue; 
+                        ImpUI.db.profile.interruptChannel = newValue; 
                     end,
                     style = 'dropdown',
                     values = {
@@ -661,7 +661,7 @@ ImpUI_Config.options = {
                         'Yell',
                     },
                     disabled = function () 
-                        return ImpUI.db.char.announceInterrupts == false;
+                        return ImpUI.db.profile.announceInterrupts == false;
                     end,
                     order = 9,
                 },
@@ -678,10 +678,10 @@ ImpUI_Config.options = {
                     name = L['Highlight Killing Blows'],
                     desc = L['When you get a Killing Blow this will be displayed prominently in the center of the screen.'],
                     get = function ()
-                        return ImpUI.db.char.killingBlows;
+                        return ImpUI.db.profile.killingBlows;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killingBlows = newValue; 
+                        ImpUI.db.profile.killingBlows = newValue; 
                     end,
                     order = 11,
                 },
@@ -691,13 +691,13 @@ ImpUI_Config.options = {
                     name = L['Killing Blow Message'],
                     desc = L['The message that is displayed in the center of the screen.'],
                     get = function ()
-                        return ImpUI.db.char.killingBlowMessage;
+                        return ImpUI.db.profile.killingBlowMessage;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killingBlowMessage = newValue; 
+                        ImpUI.db.profile.killingBlowMessage = newValue; 
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.killingBlows == false;
+                        return ImpUI.db.profile.killingBlows == false;
                     end,
                     order = 12,
                 },
@@ -707,13 +707,13 @@ ImpUI_Config.options = {
                     name = L['Colour'],
                     desc = L['The colour of the Killing Blow notification.'],
                     get = function ()
-                        return Helpers.colour_unpack(ImpUI.db.char.killingBlowColour);
+                        return Helpers.colour_unpack(ImpUI.db.profile.killingBlowColour);
                     end,
                     set = function (_, r, g, b, a)
-                        ImpUI.db.char.killingBlowColour = Helpers.colour_pack(r, g, b, a);
+                        ImpUI.db.profile.killingBlowColour = Helpers.colour_pack(r, g, b, a);
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.killingBlows == false;
+                        return ImpUI.db.profile.killingBlows == false;
                     end,
                     hasAlpha = false,
                     order = 13,
@@ -727,13 +727,13 @@ ImpUI_Config.options = {
                     max = 104,
                     step = 1,
                     get = function ()
-                        return ImpUI.db.char.killingBlowSize;
+                        return ImpUI.db.profile.killingBlowSize;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killingBlowSize = newValue; 
+                        ImpUI.db.profile.killingBlowSize = newValue; 
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.killingBlows == false;
+                        return ImpUI.db.profile.killingBlows == false;
                     end,
                     isPercent = false,
                     order = 14,
@@ -746,13 +746,13 @@ ImpUI_Config.options = {
                     dialogControl = 'LSM30_Font',
                     values = LSM:HashTable( LSM.MediaType.FONT ),
                     get = function ()
-                        return ImpUI.db.char.killingBlowFont;
+                        return ImpUI.db.profile.killingBlowFont;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killingBlowFont = newValue; 
+                        ImpUI.db.profile.killingBlowFont = newValue; 
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.killingBlows == false;
+                        return ImpUI.db.profile.killingBlows == false;
                     end,
                     order = 15,
                 },
@@ -762,13 +762,13 @@ ImpUI_Config.options = {
                     name = L['In World'],
                     desc = L['Notification will display in World content.'],
                     get = function ()
-                        return ImpUI.db.char.killingBlowInWorld;
+                        return ImpUI.db.profile.killingBlowInWorld;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killingBlowInWorld = newValue;
+                        ImpUI.db.profile.killingBlowInWorld = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.killingBlows == false;
+                        return ImpUI.db.profile.killingBlows == false;
                     end,
                     order = 16,
                 },
@@ -778,13 +778,13 @@ ImpUI_Config.options = {
                     name = L['In PvP'],
                     desc = L['Notification will display in PvP content.'],
                     get = function ()
-                        return ImpUI.db.char.killingBlowInPvP;
+                        return ImpUI.db.profile.killingBlowInPvP;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killingBlowInPvP = newValue;
+                        ImpUI.db.profile.killingBlowInPvP = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.killingBlows == false;
+                        return ImpUI.db.profile.killingBlows == false;
                     end,
                     order = 17,
                 },
@@ -794,13 +794,13 @@ ImpUI_Config.options = {
                     name = L['In Instance'],
                     desc = L['Notification will display in 5 Man instanced content.'],
                     get = function ()
-                        return ImpUI.db.char.killingBlowInInstance;
+                        return ImpUI.db.profile.killingBlowInInstance;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killingBlowInInstance = newValue;
+                        ImpUI.db.profile.killingBlowInInstance = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.killingBlows == false;
+                        return ImpUI.db.profile.killingBlows == false;
                     end,
                     order = 18,
                 },
@@ -810,13 +810,13 @@ ImpUI_Config.options = {
                     name = L['In Raid'],
                     desc = L['Notification will display in instanced raid content.'],
                     get = function ()
-                        return ImpUI.db.char.killingBlowInRaid;
+                        return ImpUI.db.profile.killingBlowInRaid;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killingBlowInRaid = newValue;
+                        ImpUI.db.profile.killingBlowInRaid = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.killingBlows == false;
+                        return ImpUI.db.profile.killingBlows == false;
                     end,
                     order = 19,
                 },
@@ -833,10 +833,10 @@ ImpUI_Config.options = {
                     name = L['Automatic Release'],
                     desc = L['Automatically release your spirit when you die.'] ,
                     get = function ()
-                        return ImpUI.db.char.autoRel;
+                        return ImpUI.db.profile.autoRel;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.autoRel = newValue;
+                        ImpUI.db.profile.autoRel = newValue;
                     end,
                     order = 21,
                 },
@@ -846,13 +846,13 @@ ImpUI_Config.options = {
                     name = L['In World'],
                     desc = '',
                     get = function ()
-                        return ImpUI.db.char.autoRelInWorld;
+                        return ImpUI.db.profile.autoRelInWorld;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.autoRelInWorld = newValue;
+                        ImpUI.db.profile.autoRelInWorld = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.autoRel == false;
+                        return ImpUI.db.profile.autoRel == false;
                     end,
                     order = 22,
                 },
@@ -862,13 +862,13 @@ ImpUI_Config.options = {
                     name = L['In Instance'],
                     desc = '',
                     get = function ()
-                        return ImpUI.db.char.autoRelInInstance;
+                        return ImpUI.db.profile.autoRelInInstance;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.autoRelInInstance = newValue;
+                        ImpUI.db.profile.autoRelInInstance = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.autoRel == false;
+                        return ImpUI.db.profile.autoRel == false;
                     end,
                     order = 23,
                 },
@@ -878,13 +878,13 @@ ImpUI_Config.options = {
                     name = L['In PvP'],
                     desc = '',
                     get = function ()
-                        return ImpUI.db.char.autoRelInPvP;
+                        return ImpUI.db.profile.autoRelInPvP;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.autoRelInPvP = newValue;
+                        ImpUI.db.profile.autoRelInPvP = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.autoRel == false;
+                        return ImpUI.db.profile.autoRel == false;
                     end,
                     order = 23,
                 },
@@ -894,13 +894,13 @@ ImpUI_Config.options = {
                     name = L['In Raid'],
                     desc = '',
                     get = function ()
-                        return ImpUI.db.char.autoRelInRaid;
+                        return ImpUI.db.profile.autoRelInRaid;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.autoRelInRaid = newValue;
+                        ImpUI.db.profile.autoRelInRaid = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.autoRel == false;
+                        return ImpUI.db.profile.autoRel == false;
                     end,
                     order = 24,
                 }
@@ -926,10 +926,10 @@ ImpUI_Config.options = {
                     name = L['Player Co-ordinates'],
                     desc = L['Adds a frame to the Mini Map showing the players location in the world. Does not work in Dungeons.'],
                     get = function ()
-                        return ImpUI.db.char.showCoords;
+                        return ImpUI.db.profile.showCoords;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.showCoords = newValue;
+                        ImpUI.db.profile.showCoords = newValue;
                     end,
                     order = 2,
                 },
@@ -941,14 +941,14 @@ ImpUI_Config.options = {
                     dialogControl = 'LSM30_Font',
                     values = LSM:HashTable( LSM.MediaType.FONT ),
                     get = function ()
-                        return ImpUI.db.char.minimapCoordsFont;
+                        return ImpUI.db.profile.minimapCoordsFont;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.minimapCoordsFont = newValue;
+                        ImpUI.db.profile.minimapCoordsFont = newValue;
                         ImpUI_MiniMap:StyleCoords();
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.showCoords == false;
+                        return ImpUI.db.profile.showCoords == false;
                     end,
                     order = 3,
                 },
@@ -958,14 +958,14 @@ ImpUI_Config.options = {
                     name = L['Colour'],
                     desc = L['The colour of the Minimap Co-ordinates Display.'],
                     get = function ()
-                        return Helpers.colour_unpack(ImpUI.db.char.minimapCoordsColour);
+                        return Helpers.colour_unpack(ImpUI.db.profile.minimapCoordsColour);
                     end,
                     set = function (_, r, g, b, a)
-                        ImpUI.db.char.minimapCoordsColour = Helpers.colour_pack(r, g, b, a);
+                        ImpUI.db.profile.minimapCoordsColour = Helpers.colour_pack(r, g, b, a);
                         ImpUI_MiniMap:StyleCoords();
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.showCoords == false;
+                        return ImpUI.db.profile.showCoords == false;
                     end,
                     hasAlpha = false,
                     order = 4,
@@ -979,14 +979,14 @@ ImpUI_Config.options = {
                     max = 26,
                     step = 1,
                     get = function ()
-                        return ImpUI.db.char.minimapCoordsSize;
+                        return ImpUI.db.profile.minimapCoordsSize;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.minimapCoordsSize = newValue;
+                        ImpUI.db.profile.minimapCoordsSize = newValue;
                         ImpUI_MiniMap:StyleCoords();
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.showCoords == false;
+                        return ImpUI.db.profile.showCoords == false;
                     end,
                     isPercent = false,
                     order = 5,
@@ -999,10 +999,10 @@ ImpUI_Config.options = {
                     dialogControl = 'LSM30_Font',
                     values = LSM:HashTable( LSM.MediaType.FONT ),
                     get = function ()
-                        return ImpUI.db.char.minimapZoneTextFont;
+                        return ImpUI.db.profile.minimapZoneTextFont;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.minimapZoneTextFont = newValue;
+                        ImpUI.db.profile.minimapZoneTextFont = newValue;
                         ImpUI_MiniMap:StyleMap();
                     end,
                     order = 6,
@@ -1016,10 +1016,10 @@ ImpUI_Config.options = {
                     max = 26,
                     step = 1,
                     get = function ()
-                        return ImpUI.db.char.minimapZoneTextSize;
+                        return ImpUI.db.profile.minimapZoneTextSize;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.minimapZoneTextSize = newValue;
+                        ImpUI.db.profile.minimapZoneTextSize = newValue;
                         ImpUI_MiniMap:StyleMap();
                     end,
                     isPercent = false,
@@ -1033,10 +1033,10 @@ ImpUI_Config.options = {
                     dialogControl = 'LSM30_Font',
                     values = LSM:HashTable( LSM.MediaType.FONT ),
                     get = function ()
-                        return ImpUI.db.char.minimapClockFont;
+                        return ImpUI.db.profile.minimapClockFont;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.minimapClockFont = newValue;
+                        ImpUI.db.profile.minimapClockFont = newValue;
                         ImpUI_MiniMap:StyleClock();
                     end,
                     order = 8,
@@ -1050,10 +1050,10 @@ ImpUI_Config.options = {
                     max = 22,
                     step = 1,
                     get = function ()
-                        return ImpUI.db.char.minimapClockSize;
+                        return ImpUI.db.profile.minimapClockSize;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.minimapClockSize = newValue;
+                        ImpUI.db.profile.minimapClockSize = newValue;
                         ImpUI_MiniMap:StyleClock();
                     end,
                     isPercent = false,
@@ -1081,10 +1081,10 @@ ImpUI_Config.options = {
                     name = L['Enable AFK Mode'],
                     desc = L['After you go AFK the interface will fade away, pan your camera and display your Character in all their glory.'],
                     get = function ()
-                        return ImpUI.db.char.afkMode;
+                        return ImpUI.db.profile.afkMode;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.afkMode = newValue;
+                        ImpUI.db.profile.afkMode = newValue;
                     end,
                     order = 1,
                 },
@@ -1093,10 +1093,10 @@ ImpUI_Config.options = {
                     name = L['Auto Repair'],
                     desc = L['Automatically repairs your armour when you visit a merchant that can repair.'],
                     get = function ()
-                        return ImpUI.db.char.autoRepair;
+                        return ImpUI.db.profile.autoRepair;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.autoRepair = newValue;
+                        ImpUI.db.profile.autoRepair = newValue;
                     end,
                     order = 2,
                 },
@@ -1105,10 +1105,10 @@ ImpUI_Config.options = {
                     name = L['Auto Sell Trash'],
                     desc = L['Automatically sells any grey items that are in your inventory.'],
                     get = function ()
-                        return ImpUI.db.char.autoSell;
+                        return ImpUI.db.profile.autoSell;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.autoSell = newValue;
+                        ImpUI.db.profile.autoSell = newValue;
                     end,
                     order = 4,
                 },
@@ -1125,10 +1125,10 @@ ImpUI_Config.options = {
                     name = L['Minify Blizzard Strings'],
                     desc = L['Shortens chat messages such as Loot Received, Exp Gain, Skill Gain and Chat Channels.'],
                     get = function ()
-                        return ImpUI.db.char.minifyStrings;
+                        return ImpUI.db.profile.minifyStrings;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.minifyStrings = newValue;
+                        ImpUI.db.profile.minifyStrings = newValue;
 
                         if (newValue == true) then
                             ImpUI_Chat:RestoreStrings();
@@ -1145,10 +1145,10 @@ ImpUI_Config.options = {
                     name = L['Style Chat'],
                     desc = L['Styles the Blizzard Chat frame to better match the rest of the UI.'],
                     get = function ()
-                        return ImpUI.db.char.styleChat;
+                        return ImpUI.db.profile.styleChat;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.styleChat = newValue;
+                        ImpUI.db.profile.styleChat = newValue;
 
                         if (newValue == true) then
                             ImpUI_Chat:StyleChat();
@@ -1166,14 +1166,14 @@ ImpUI_Config.options = {
                     dialogControl = 'LSM30_Font',
                     values = LSM:HashTable( LSM.MediaType.FONT ),
                     get = function ()
-                        return ImpUI.db.char.chatFont;
+                        return ImpUI.db.profile.chatFont;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.chatFont = newValue;
+                        ImpUI.db.profile.chatFont = newValue;
                         ImpUI_Chat:StyleChat();
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.styleChat == false;
+                        return ImpUI.db.profile.styleChat == false;
                     end,
                     order = 9,
                 },
@@ -1183,14 +1183,14 @@ ImpUI_Config.options = {
                     name = L['Outline Font'],
                     desc = L['Applies a thin outline to text rendered in the chat windows.'],
                     get = function ()
-                        return ImpUI.db.char.outlineChat;
+                        return ImpUI.db.profile.outlineChat;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.outlineChat = newValue;
+                        ImpUI.db.profile.outlineChat = newValue;
                         ImpUI_Chat:StyleChat();
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.styleChat == false;
+                        return ImpUI.db.profile.styleChat == false;
                     end,
                     order = 10,
                 },
@@ -1208,10 +1208,10 @@ ImpUI_Config.options = {
                     dialogControl = 'LSM30_Font',
                     values = LSM:HashTable( LSM.MediaType.FONT ),
                     get = function ()
-                        return ImpUI.db.char.primaryInterfaceFont;
+                        return ImpUI.db.profile.primaryInterfaceFont;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.primaryInterfaceFont = newValue;
+                        ImpUI.db.profile.primaryInterfaceFont = newValue;
                         ImpUI_Fonts:PrimaryFontUpdated();
                         ImpUI_Performance:StylePerformanceFrame();
                         ImpUI_Player:StyleFrame();
@@ -1232,10 +1232,10 @@ ImpUI_Config.options = {
                     name = L['Display System Statistics'],
                     desc = L['Displays FPS and Latency above the Mini Map.'],
                     get = function ()
-                        return ImpUI.db.char.performanceFrame;
+                        return ImpUI.db.profile.performanceFrame;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.performanceFrame = newValue;
+                        ImpUI.db.profile.performanceFrame = newValue;
                         ImpUI_MiniMap:StyleMap();
                     end,
                     order = 14,
@@ -1249,10 +1249,10 @@ ImpUI_Config.options = {
                     max = 23,
                     step = 1,
                     get = function ()
-                        return ImpUI.db.char.performanceFrameSize;
+                        return ImpUI.db.profile.performanceFrameSize;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.performanceFrameSize = newValue;
+                        ImpUI.db.profile.performanceFrameSize = newValue;
                         ImpUI_Performance:StylePerformanceFrame();
                     end,
                     isPercent = false,
@@ -1270,10 +1270,10 @@ ImpUI_Config.options = {
                     name = L['Enable Kill Feed'],
                     desc = L['Displays a feed of the last 5 kills that occur around you.'],
                     get = function ()
-                        return ImpUI.db.char.killFeed;
+                        return ImpUI.db.profile.killFeed;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killFeed = newValue;
+                        ImpUI.db.profile.killFeed = newValue;
                     end,
                     order = 17,
                 },
@@ -1285,14 +1285,14 @@ ImpUI_Config.options = {
                     dialogControl = 'LSM30_Font',
                     values = LSM:HashTable( LSM.MediaType.FONT ),
                     get = function ()
-                        return ImpUI.db.char.killFeedFont;
+                        return ImpUI.db.profile.killFeedFont;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killFeedFont = newValue;
+                        ImpUI.db.profile.killFeedFont = newValue;
                         ImpUI_Killfeed:StyleKillFeed();
                     end,
                     disabled = function ()
-                        return ImpUI.db.char.killFeed == false;
+                        return ImpUI.db.profile.killFeed == false;
                     end,
                     order = 18,
                 },
@@ -1305,14 +1305,14 @@ ImpUI_Config.options = {
                     max = 52,
                     step = 1,
                     get = function ()
-                        return ImpUI.db.char.killFeedSize;
+                        return ImpUI.db.profile.killFeedSize;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killFeedSize = newValue;
+                        ImpUI.db.profile.killFeedSize = newValue;
                         ImpUI_Killfeed:StyleKillFeed();
                     end,
                     disabled = function ()
-                        return ImpUI.db.char.killFeed == false;
+                        return ImpUI.db.profile.killFeed == false;
                     end,
                     isPercent = false,
                     order = 19,
@@ -1326,14 +1326,14 @@ ImpUI_Config.options = {
                     max = 52,
                     step = 1,
                     get = function ()
-                        return ImpUI.db.char.killFeedSpacing;
+                        return ImpUI.db.profile.killFeedSpacing;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killFeedSpacing = newValue;
+                        ImpUI.db.profile.killFeedSpacing = newValue;
                         ImpUI_Killfeed:StyleKillFeed();
                     end,
                     disabled = function ()
-                        return ImpUI.db.char.killFeed == false;
+                        return ImpUI.db.profile.killFeed == false;
                     end,
                     isPercent = false,
                     order = 20,
@@ -1344,13 +1344,13 @@ ImpUI_Config.options = {
                     name = L['Show Casted Spell'],
                     desc = L['Show the Spell that caused a death.'],
                     get = function ()
-                        return ImpUI.db.char.killFeedShowSpell;
+                        return ImpUI.db.profile.killFeedShowSpell;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killFeedShowSpell = newValue;
+                        ImpUI.db.profile.killFeedShowSpell = newValue;
                     end,
                     disabled = function ()
-                        return ImpUI.db.char.killFeed == false;
+                        return ImpUI.db.profile.killFeed == false;
                     end,
                     order = 21,
                 },
@@ -1360,13 +1360,13 @@ ImpUI_Config.options = {
                     name = L['Show Damage'],
                     desc = L['Show how much damage the Creature or Player took.'],
                     get = function ()
-                        return ImpUI.db.char.killFeedShowDamage;
+                        return ImpUI.db.profile.killFeedShowDamage;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killFeedShowDamage = newValue;
+                        ImpUI.db.profile.killFeedShowDamage = newValue;
                     end,
                     disabled = function ()
-                        return ImpUI.db.char.killFeed == false;
+                        return ImpUI.db.profile.killFeed == false;
                     end,
                     order = 22,
                 },
@@ -1376,13 +1376,13 @@ ImpUI_Config.options = {
                     name = L['Hide When Inactive'],
                     desc = L['Hides the Kill Feed after no new events have occured for a short period.'],
                     get = function ()
-                        return ImpUI.db.char.killFeedFadeInactive;
+                        return ImpUI.db.profile.killFeedFadeInactive;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killFeedFadeInactive = newValue;
+                        ImpUI.db.profile.killFeedFadeInactive = newValue;
                     end,
                     disabled = function ()
-                        return ImpUI.db.char.killFeed == false;
+                        return ImpUI.db.profile.killFeed == false;
                     end,
                     order = 23,
                 },
@@ -1392,13 +1392,13 @@ ImpUI_Config.options = {
                     name = L['In World'],
                     desc = '',
                     get = function ()
-                        return ImpUI.db.char.killFeedInWorld;
+                        return ImpUI.db.profile.killFeedInWorld;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killFeedInWorld = newValue;
+                        ImpUI.db.profile.killFeedInWorld = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.killFeed == false;
+                        return ImpUI.db.profile.killFeed == false;
                     end,
                     order = 24,
                 },
@@ -1408,13 +1408,13 @@ ImpUI_Config.options = {
                     name = L['In Instance'],
                     desc = '',
                     get = function ()
-                        return ImpUI.db.char.killFeedInInstance;
+                        return ImpUI.db.profile.killFeedInInstance;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killFeedInInstance = newValue;
+                        ImpUI.db.profile.killFeedInInstance = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.killFeed == false;
+                        return ImpUI.db.profile.killFeed == false;
                     end,
                     order = 25,
                 },
@@ -1424,13 +1424,13 @@ ImpUI_Config.options = {
                     name = L['In PvP'],
                     desc = '',
                     get = function ()
-                        return ImpUI.db.char.killFeedInPvP;
+                        return ImpUI.db.profile.killFeedInPvP;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killFeedInPvP = newValue;
+                        ImpUI.db.profile.killFeedInPvP = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.killFeed == false;
+                        return ImpUI.db.profile.killFeed == false;
                     end,
                     order = 26,
                 },
@@ -1440,13 +1440,13 @@ ImpUI_Config.options = {
                     name = L['In Raid'],
                     desc = '',
                     get = function ()
-                        return ImpUI.db.char.killFeedInRaid;
+                        return ImpUI.db.profile.killFeedInRaid;
                     end,
                     set = function (info, newValue)
-                        ImpUI.db.char.killFeedInRaid = newValue;
+                        ImpUI.db.profile.killFeedInRaid = newValue;
                     end,
                     disabled = function () 
-                        return ImpUI.db.char.killFeed == false;
+                        return ImpUI.db.profile.killFeed == false;
                     end,
                     order = 27,
                 }

--- a/core.lua
+++ b/core.lua
@@ -121,6 +121,9 @@ function ImpUI:OnInitialize()
     -- Set up DB
     self.db = LibStub('AceDB-3.0'):New('ImpUI_DB', ImpUI_Config.defaults, true);
 
+    -- Enable Profile Management
+	ImpUI_Config.options.args.profile = LibStub("AceDBOptions-3.0"):GetOptionsTable(self.db);
+
     -- Register Config
     LibStub('AceConfig-3.0'):RegisterOptionsTable('ImprovedBlizzardUI_Classic', ImpUI_Config.options);
 

--- a/core.lua
+++ b/core.lua
@@ -109,8 +109,11 @@ function ImpUI:HandleSlash(input)
     end
 end
 
-function ImpUI:Reload()
-    ReloadUI();
+function ImpUI:ReloadModules()
+    for name, module in ImpUI:IterateModules() do
+        module:Disable();
+        module:Enable();
+    end
 end
 
 --[[
@@ -129,9 +132,9 @@ function ImpUI:OnInitialize()
 	ImpUI_Config.options.args.profile = LibStub("AceDBOptions-3.0"):GetOptionsTable(self.db);
 
     -- Reloads after active profile is changed
-    self.db.RegisterCallback(self, "OnProfileChanged", "Reload")
-    self.db.RegisterCallback(self, "OnProfileCopied", "Reload")
-    self.db.RegisterCallback(self, "OnProfileReset", "Reload")
+    self.db.RegisterCallback(self, "OnProfileChanged", "ReloadModules")
+    self.db.RegisterCallback(self, "OnProfileCopied", "ReloadModules")
+    self.db.RegisterCallback(self, "OnProfileReset", "ReloadModules")
 
     -- Register Config
     LibStub('AceConfig-3.0'):RegisterOptionsTable('ImprovedBlizzardUI_Classic', ImpUI_Config.options);

--- a/core.lua
+++ b/core.lua
@@ -109,6 +109,10 @@ function ImpUI:HandleSlash(input)
     end
 end
 
+function ImpUI:Reload()
+    ReloadUI();
+end
+
 --[[
 	Fires when the Addon is Initialised.
 	
@@ -123,6 +127,11 @@ function ImpUI:OnInitialize()
 
     -- Enable Profile Management
 	ImpUI_Config.options.args.profile = LibStub("AceDBOptions-3.0"):GetOptionsTable(self.db);
+
+    -- Reloads after active profile is changed
+    self.db.RegisterCallback(self, "OnProfileChanged", "Reload")
+    self.db.RegisterCallback(self, "OnProfileCopied", "Reload")
+    self.db.RegisterCallback(self, "OnProfileReset", "Reload")
 
     -- Register Config
     LibStub('AceConfig-3.0'):RegisterOptionsTable('ImprovedBlizzardUI_Classic', ImpUI_Config.options);

--- a/embeds.xml
+++ b/embeds.xml
@@ -12,6 +12,7 @@
     <Include file='Libs\Ace3\AceAddon-3.0\AceAddon-3.0.xml'/>
     <Include file='Libs\Ace3\AceEvent-3.0\AceEvent-3.0.xml'/>
     <Include file='Libs\Ace3\AceDB-3.0\AceDB-3.0.xml'/>
+    <Include file='Libs\Ace3\AceDBOptions-3.0\AceDBOptions-3.0.xml'/>
     <Include file="Libs\Ace3\AceLocale-3.0\AceLocale-3.0.xml"/>
     <Include file='Libs\Ace3\AceConsole-3.0\AceConsole-3.0.xml'/>
     <Include file='Libs\Ace3\AceGUI-3.0\AceGUI-3.0.xml'/>

--- a/modules/bars/buffs.lua
+++ b/modules/bars/buffs.lua
@@ -29,7 +29,7 @@ end
 function ImpUI_Buffs:Lock()
     local point, relativeTo, relativePoint, xOfs, yOfs = dragFrame:GetPoint();
 
-    ImpUI.db.char.buffsPosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
+    ImpUI.db.profile.buffsPosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
 
     dragFrame:Hide();
 end
@@ -38,8 +38,8 @@ end
 	Loads the position of the Buff Frame from SavedVariables.
 ]]
 function ImpUI_Buffs:LoadPosition()
-    local pos = ImpUI.db.char.buffsPosition;
-    local scale = ImpUI.db.char.buffsScale;
+    local pos = ImpUI.db.profile.buffsPosition;
+    local scale = ImpUI.db.profile.buffsScale;
     
     -- Set Drag Frame Position
     dragFrame:SetPoint(pos.point, pos.relativeTo, pos.relativePoint, pos.x, pos.y);

--- a/modules/bars/castbar.lua
+++ b/modules/bars/castbar.lua
@@ -42,11 +42,11 @@ local function CreateCastingTimer(frame, pos)
     frame.timer = nil;
 
     -- Get Font
-    local font = Helpers.get_styled_font(ImpUI.db.char.primaryInterfaceFont);
+    local font = Helpers.get_styled_font(ImpUI.db.profile.primaryInterfaceFont);
 
     -- Create Timers
     frame.timer = frame:CreateFontString(nil);
-    frame.timer:SetFont(font.font, ImpUI.db.char.castBarFontSize, font.flags);
+    frame.timer:SetFont(font.font, ImpUI.db.profile.castBarFontSize, font.flags);
     frame.timer:SetPoint(pos.point, frame, pos.relativePoint, pos.x, pos.y);
     frame.timer:SetTextColor(font.r, font.g, font.b, font.a);
     frame.timer.updateDelay = updateDelay;
@@ -72,14 +72,14 @@ function ImpUI_CastBar:StyleFrame()
     KillTimer(CastingBarFrame); -- Kill If Needed
 
     -- Get Font
-    font = Helpers.get_styled_font(ImpUI.db.char.primaryInterfaceFont);
+    font = Helpers.get_styled_font(ImpUI.db.profile.primaryInterfaceFont);
 
     -- Set Font
-    CastingBarFrame.Text:SetFont(font.font, ImpUI.db.char.castBarFontSize, font.flags);
+    CastingBarFrame.Text:SetFont(font.font, ImpUI.db.profile.castBarFontSize, font.flags);
     CastingBarFrame.Text:SetTextColor(font.r, font.g, font.b, font.a);
 
     -- Cast Bar
-    if (ImpUI.db.char.castBarPlayerTimer) then
+    if (ImpUI.db.profile.castBarPlayerTimer) then
         CreateCastingTimer(CastingBarFrame, Helpers.pack_position('TOP', nil, 'BOTTOM', 0, 35));
     end
 end
@@ -97,7 +97,7 @@ end
 function ImpUI_CastBar:Lock()
     local point, relativeTo, relativePoint, xOfs, yOfs = dragFrame:GetPoint();
 
-    ImpUI.db.char.castBarPosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
+    ImpUI.db.profile.castBarPosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
 
     dragFrame:Hide();
 end
@@ -106,8 +106,8 @@ end
 	Loads the position of the Castbar Frame from SavedVariables.
 ]]
 function ImpUI_CastBar:LoadPosition()
-    local pos = ImpUI.db.char.castBarPosition;
-    local scale = ImpUI.db.char.castBarScale;
+    local pos = ImpUI.db.profile.castBarPosition;
+    local scale = ImpUI.db.profile.castBarScale;
     
     -- Set Drag Frame Position
     dragFrame:SetPoint(pos.point, pos.relativeTo, pos.relativePoint, pos.x, pos.y);

--- a/modules/combat/autorelease.lua
+++ b/modules/combat/autorelease.lua
@@ -31,7 +31,7 @@ end
     @ return void
 ]]
 function ImpUI_Ressurect:PLAYER_DEAD()
-    if (ImpUI.db.char.autoRel == false) then return; end
+    if (ImpUI.db.profile.autoRel == false) then return; end
 
     if (HasSoulstone()) then return; end -- If we can self res (Ankh etc) then don't do anything.
 
@@ -40,10 +40,10 @@ function ImpUI_Ressurect:PLAYER_DEAD()
     local shouldRelease = false;
 
     -- Figure out if we should show based on config.
-    if (instanceType == 'none' and ImpUI.db.char.killingBlowInWorld) then shouldRelease = true; end
-    if (instanceType == 'party' and ImpUI.db.char.killingBlowInInstance) then shouldRelease = true; end
-    if (instanceType == 'raid' and ImpUI.db.char.killingBlowInRaid) then shouldRelease = true; end
-    if((instanceType == 'pvp' or instanceType == 'arena' or (instanceType == 'none' and GetZonePVPInfo() == 'combat')) and ImpUI.db.char.killingBlowInPvP) then shouldRelease = true; end
+    if (instanceType == 'none' and ImpUI.db.profile.killingBlowInWorld) then shouldRelease = true; end
+    if (instanceType == 'party' and ImpUI.db.profile.killingBlowInInstance) then shouldRelease = true; end
+    if (instanceType == 'raid' and ImpUI.db.profile.killingBlowInRaid) then shouldRelease = true; end
+    if((instanceType == 'pvp' or instanceType == 'arena' or (instanceType == 'none' and GetZonePVPInfo() == 'combat')) and ImpUI.db.profile.killingBlowInPvP) then shouldRelease = true; end
 
     if (shouldRelease) then
         RepopMe();

--- a/modules/combat/healthwarning.lua
+++ b/modules/combat/healthwarning.lua
@@ -24,7 +24,7 @@ local canShowQuarter = true;
     @ return void
 ]]
 function ImpUI_Health:UNIT_HEALTH(event, ...)
-    if (ImpUI.db.char.healthWarning == false) then return; end
+    if (ImpUI.db.profile.healthWarning == false) then return; end
 
     if (... == 'player') then
         local hp = UnitHealth('player') / UnitHealthMax('player');
@@ -33,12 +33,12 @@ function ImpUI_Health:UNIT_HEALTH(event, ...)
             canShowHalf = true;
         end
 
-        local size = ImpUI.db.char.healthWarningSize;
+        local size = ImpUI.db.profile.healthWarningSize;
 
         if ( hp <= 0.50 and hp > 0.25 and canShowHalf == true) then
             -- Get font config options.
-            local font = ImpUI.db.char.healthWarningFont;
-            local colour = ImpUI.db.char.healthWarningHalfColour;
+            local font = ImpUI.db.profile.healthWarningFont;
+            local colour = ImpUI.db.profile.healthWarningHalfColour;
 
             OSD:AddMessage( L['HP < 50% !'], font, size, colour.r, colour.g, colour.b, 5.0 );
 
@@ -47,8 +47,8 @@ function ImpUI_Health:UNIT_HEALTH(event, ...)
             return;
         elseif(hp < 0.25 and canShowQuarter == true) then
             -- Get font config options.
-            local font = ImpUI.db.char.healthWarningFont;
-            local colour = ImpUI.db.char.healthWarningQuarterColour;
+            local font = ImpUI.db.profile.healthWarningFont;
+            local colour = ImpUI.db.profile.healthWarningQuarterColour;
 
             OSD:AddMessage( L['HP < 25% !!!'], font, size, colour.r, colour.g, colour.b, 5.0 );
 

--- a/modules/combat/interrupts.lua
+++ b/modules/combat/interrupts.lua
@@ -25,7 +25,7 @@ local CONF_YELL = 3;
     @ return void
 ]]
 function ImpUI_Interrupts:COMBAT_LOG_EVENT_UNFILTERED()
-    if (ImpUI.db.char.announceInterrupts == false) then return; end
+    if (ImpUI.db.profile.announceInterrupts == false) then return; end
 
     local _, event, _, sourceGUID, _, _, _, _, destName, _, _, _, _, _, _, spellName, _, _, _, _, _ = CombatLogGetCurrentEventInfo();
 
@@ -33,7 +33,7 @@ function ImpUI_Interrupts:COMBAT_LOG_EVENT_UNFILTERED()
         local message = L['Interrupted X on Y'](spellName, destName);
 
         local channel;
-        local config = ImpUI.db.char.interruptChannel;
+        local config = ImpUI.db.profile.interruptChannel;
 
         if (config == CONF_AUTO) then -- Auto
             channel = IsInGroup(2) and 'INSTANCE_CHAT' or IsInRaid() and 'RAID' or IsInGroup() and 'PARTY' or 'SAY';

--- a/modules/combat/killingblows.lua
+++ b/modules/combat/killingblows.lua
@@ -23,7 +23,7 @@ local GetZonePVPInfo = GetZonePVPInfo;
     @ return void
 ]]
 function ImpUI_KillingBlows:COMBAT_LOG_EVENT_UNFILTERED()
-    if (ImpUI.db.char.killingBlows == false) then return; end
+    if (ImpUI.db.profile.killingBlows == false) then return; end
 
     local _, event, _, sourceGUID, sourceName, _, _, destGUID, destName, _, _, _, spellName, _, amount, _, _, _, _, _, _ = CombatLogGetCurrentEventInfo();
     local _, instanceType = IsInInstance();
@@ -33,16 +33,16 @@ function ImpUI_KillingBlows:COMBAT_LOG_EVENT_UNFILTERED()
             local shouldShow = false;
 
             -- Figure out if we should show based on config.
-            if (instanceType == 'none' and ImpUI.db.char.killingBlowInWorld) then shouldShow = true; end
-            if (instanceType == 'party' and ImpUI.db.char.killingBlowInInstance) then shouldShow = true; end
-            if (instanceType == 'raid' and ImpUI.db.char.killingBlowInRaid) then shouldShow = true; end
-            if((instanceType == 'pvp' or instanceType == 'arena' or (instanceType == 'none' and GetZonePVPInfo() == 'combat')) and ImpUI.db.char.killingBlowInPvP) then shouldShow = true; end
+            if (instanceType == 'none' and ImpUI.db.profile.killingBlowInWorld) then shouldShow = true; end
+            if (instanceType == 'party' and ImpUI.db.profile.killingBlowInInstance) then shouldShow = true; end
+            if (instanceType == 'raid' and ImpUI.db.profile.killingBlowInRaid) then shouldShow = true; end
+            if((instanceType == 'pvp' or instanceType == 'arena' or (instanceType == 'none' and GetZonePVPInfo() == 'combat')) and ImpUI.db.profile.killingBlowInPvP) then shouldShow = true; end
 
             if (shouldShow) then
-                local message = ImpUI.db.char.killingBlowMessage;
-                local font = ImpUI.db.char.killingBlowFont;
-                local size = ImpUI.db.char.killingBlowSize;
-                local colour = ImpUI.db.char.killingBlowColour;
+                local message = ImpUI.db.profile.killingBlowMessage;
+                local font = ImpUI.db.profile.killingBlowFont;
+                local size = ImpUI.db.profile.killingBlowSize;
+                local colour = ImpUI.db.profile.killingBlowColour;
     
                 OSD:AddMessage( message, font, size, colour.r, colour.g, colour.b, 2.0 );
             end

--- a/modules/frames/party.lua
+++ b/modules/frames/party.lua
@@ -18,10 +18,10 @@ local dragFrame;
     @ return void
 ]]
 function ImpUI_Party:StyleFrames()
-    if (ImpUI.db.char.styleUnitFrames == false) then return; end
+    if (ImpUI.db.profile.styleUnitFrames == false) then return; end
 
     -- Fonts
-    local font = Helpers.get_styled_font(ImpUI.db.char.primaryInterfaceFont);
+    local font = Helpers.get_styled_font(ImpUI.db.profile.primaryInterfaceFont);
 
     -- Style Each Party Frame
     for i = 1, 4 do
@@ -43,8 +43,8 @@ end
 	Loads the position of the Party Frames from SavedVariables.
 ]]
 function ImpUI_Party:LoadPosition()
-    local pos = ImpUI.db.char.partyFramePosition;
-    local scale = ImpUI.db.char.partyFrameScale;
+    local pos = ImpUI.db.profile.partyFramePosition;
+    local scale = ImpUI.db.profile.partyFrameScale;
     local offset = 0;
     
     -- Set Drag Frame Position
@@ -98,7 +98,7 @@ end
 function ImpUI_Party:Lock()
     local point, relativeTo, relativePoint, xOfs, yOfs = dragFrame:GetPoint();
 
-    ImpUI.db.char.partyFramePosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
+    ImpUI.db.profile.partyFramePosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
 
     HideFrames();
 

--- a/modules/frames/player.lua
+++ b/modules/frames/player.lua
@@ -40,7 +40,7 @@ end
     @ param int $type Honestly unsure, apparently sets it to black if > 0 but I've never seen this actually happen in game.
 ]]
 function ImpUI_Player:CombatFeedback_OnCombatEvent(self, event, flags, amount, type)
-    if(ImpUI.db.char.playerHidePortraitSpam) then
+    if(ImpUI.db.profile.playerHidePortraitSpam) then
         self.feedbackText:SetText(' ');
     end
 end
@@ -56,7 +56,7 @@ function ImpUI_Player:TogglePlayer(toggle)
         local maxMana = UnitPower('player', 0) == UnitPowerMax('player', 0);
         local hasTarget = UnitExists('target') == false;
 
-        if (toggle and maxHealth and maxMana and hasTarget and ImpUI.db.char.playerHideOOC) then
+        if (toggle and maxHealth and maxMana and hasTarget and ImpUI.db.profile.playerHideOOC) then
             PlayerFrame:Hide();
         else
             PlayerFrame:Show();
@@ -71,7 +71,7 @@ end
     @ return void
 ]]
 function ImpUI_Player:HealthBarChanged(bar)
-    if (ImpUI.db.char.playerClassColours and bar.unit == 'player') then
+    if (ImpUI.db.profile.playerClassColours and bar.unit == 'player') then
         Helpers.ApplyClassColours(bar, bar.unit);
     end
 end
@@ -83,7 +83,7 @@ end
     @ return void
 ]]
 function ImpUI_Player:StyleFrame()
-    if (ImpUI.db.char.styleUnitFrames == false) then return; end
+    if (ImpUI.db.profile.styleUnitFrames == false) then return; end
     if (InCombatLockdown() == true) then return end
 
     -- Change Texture
@@ -97,7 +97,7 @@ function ImpUI_Player:StyleFrame()
     PlayerFrameHealthBarText:SetPoint('CENTER',50,6);
 
     -- Apply Fonts and Colours
-    local font = LSM:Fetch('font', ImpUI.db.char.primaryInterfaceFont);
+    local font = LSM:Fetch('font', ImpUI.db.profile.primaryInterfaceFont);
     local _, _, flags = PlayerFrameHealthBarTextLeft:GetFont();
     local r, g, b, a = PlayerFrameHealthBarTextLeft:GetTextColor();
 
@@ -200,7 +200,7 @@ end
 function ImpUI_Player:Lock()
     local point, relativeTo, relativePoint, xOfs, yOfs = dragFrame:GetPoint();
 
-    ImpUI.db.char.playerFramePosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
+    ImpUI.db.profile.playerFramePosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
 
     dragFrame:Hide();
 end
@@ -209,8 +209,8 @@ end
 	Loads the position of the Player Frame from SavedVariables.
 ]]
 function ImpUI_Player:LoadPosition()
-    local pos = ImpUI.db.char.playerFramePosition;
-    local scale = ImpUI.db.char.playerFrameScale;
+    local pos = ImpUI.db.profile.playerFramePosition;
+    local scale = ImpUI.db.profile.playerFrameScale;
     
     -- Set Drag Frame Position
     dragFrame:SetPoint(pos.point, pos.relativeTo, pos.relativePoint, pos.x, pos.y);

--- a/modules/frames/target.lua
+++ b/modules/frames/target.lua
@@ -19,7 +19,7 @@ local UnitClassification = UnitClassification;
     @ return void
 ]]
 function ImpUI_Target:TargetofTargetHealthCheck(self)
-    if (ImpUI.db.char.targetOfTargetClassColours) then
+    if (ImpUI.db.profile.targetOfTargetClassColours) then
         Helpers.ApplyClassColours(self.healthbar, self.healthbar.unit);
     end
 end
@@ -30,7 +30,7 @@ end
     @ return void
 ]]
 function ImpUI_Target:HealthBarChanged(bar)
-    if (ImpUI.db.char.targetClassColours and bar.unit == 'target') then
+    if (ImpUI.db.profile.targetClassColours and bar.unit == 'target') then
         Helpers.ApplyClassColours(bar, bar.unit);
     end
 end
@@ -41,7 +41,7 @@ end
     @ return void
 ]]
 function ImpUI_Target:StyleFrame()
-    if (ImpUI.db.char.styleUnitFrames == false) then return; end
+    if (ImpUI.db.profile.styleUnitFrames == false) then return; end
 
     local unitClassification = UnitClassification(TargetFrame.unit);
 
@@ -70,21 +70,21 @@ function ImpUI_Target:StyleFrame()
     TargetFrame.healthbar:SetWidth(119);
 
     -- Class Colours
-    if (ImpUI.db.char.targetClassColours) then
+    if (ImpUI.db.profile.targetClassColours) then
         Helpers.ApplyClassColours(TargetFrame.healthbar, TargetFrame.healthbar.unit);
     end
 
     TargetFrame.healthbar.lockColor = true;
 
     -- Buffs on Top.
-    if (ImpUI.db.char.targetBuffsOnTop) then
+    if (ImpUI.db.profile.targetBuffsOnTop) then
         TargetFrame.buffsOnTop = true;
     else
         TargetFrame.buffsOnTop = false;
     end
 
     -- Fonts
-    local font = Helpers.get_styled_font(ImpUI.db.char.primaryInterfaceFont);
+    local font = Helpers.get_styled_font(ImpUI.db.profile.primaryInterfaceFont);
 
     TargetFrameTextureFrameName:SetTextColor(font.r, font.g, font.b, font.a);
 
@@ -123,7 +123,7 @@ end
 function ImpUI_Target:Lock()
     local point, relativeTo, relativePoint, xOfs, yOfs = dragFrame:GetPoint();
 
-    ImpUI.db.char.targetFramePosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
+    ImpUI.db.profile.targetFramePosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
 
     dragFrame:Hide();
 end
@@ -132,8 +132,8 @@ end
 	Loads the position of the Target Frame from SavedVariables.
 ]]
 function ImpUI_Target:LoadPosition()
-    local pos = ImpUI.db.char.targetFramePosition;
-    local scale = ImpUI.db.char.targetFrameScale;
+    local pos = ImpUI.db.profile.targetFramePosition;
+    local scale = ImpUI.db.profile.targetFrameScale;
     
     -- Set Drag Frame Position
     dragFrame:SetPoint(pos.point, pos.relativeTo, pos.relativePoint, pos.x, pos.y);

--- a/modules/maps/minimap.lua
+++ b/modules/maps/minimap.lua
@@ -36,8 +36,8 @@ end
     @ return void
 ]]
 function ImpUI_MiniMap:StyleClock()
-    local font = ImpUI.db.char.minimapClockFont;
-    local size = ImpUI.db.char.minimapClockSize;
+    local font = ImpUI.db.profile.minimapClockFont;
+    local size = ImpUI.db.profile.minimapClockSize;
 
     TimeManagerClockTicker:SetFont(LSM:Fetch('font', font), size, outline);
 end
@@ -51,7 +51,7 @@ end
 function ImpUI_MiniMap:StyleMap()
     MinimapCluster:ClearAllPoints();
     
-    if (ImpUI.db.char.performanceFrame == true) then
+    if (ImpUI.db.profile.performanceFrame == true) then
         MinimapCluster:SetPoint('TOPRIGHT', -15, -32);
     else
         MinimapCluster:SetPoint('TOPRIGHT', -15, -16);
@@ -67,8 +67,8 @@ function ImpUI_MiniMap:StyleMap()
     end);
 
     -- Check styling config here as rest is subjective
-    local font = ImpUI.db.char.minimapZoneTextFont;
-    local size = ImpUI.db.char.minimapZoneTextSize;
+    local font = ImpUI.db.profile.minimapZoneTextFont;
+    local size = ImpUI.db.profile.minimapZoneTextSize;
 
     MinimapZoneText:SetFont(LSM:Fetch('font', font), size, 'OUTLINE');
 end
@@ -79,9 +79,9 @@ end
     @ return void
 ]]
 function ImpUI_MiniMap:StyleCoords()
-    local font = ImpUI.db.char.minimapCoordsFont;
-    local colour = ImpUI.db.char.minimapCoordsColour;
-    local size = ImpUI.db.char.minimapCoordsSize;
+    local font = ImpUI.db.profile.minimapCoordsFont;
+    local colour = ImpUI.db.profile.minimapCoordsColour;
+    local size = ImpUI.db.profile.minimapCoordsSize;
 
     coords.text:SetFont(LSM:Fetch('font', font), size, 'OUTLINE');
     coords.text:SetTextColor(colour.r, colour.g, colour.b, colour.a);
@@ -96,7 +96,7 @@ function ImpUI_MiniMap:UpdateCoords()
     local inInstance, instanceType = IsInInstance();
 
     -- If configuration disabled or we're in a dungeon then just set to blank.
-    if (ImpUI.db.char.showCoords == false or inInstance == true) then
+    if (ImpUI.db.profile.showCoords == false or inInstance == true) then
         coords.text:SetText('');
         return;
     end

--- a/modules/misc/afkmode.lua
+++ b/modules/misc/afkmode.lua
@@ -62,7 +62,7 @@ end
 ]]
 function ImpUI_AFK:ToggleSpin(spin)
 	-- If disabled in Config do nothing.
-	if (ImpUI.db.char.afkMode == false) then return; end
+	if (ImpUI.db.profile.afkMode == false) then return; end
 
     -- If the Player is in combat then just do nothing
     if (InCombatLockdown()) then return; end

--- a/modules/misc/autorepair.lua
+++ b/modules/misc/autorepair.lua
@@ -24,7 +24,7 @@ local GetMoney = GetMoney;
     @ return void
 ]]
 function ImpUI_Repair:MERCHANT_SHOW()
-    if (ImpUI.db.char.autoRepair and CanMerchantRepair()) then
+    if (ImpUI.db.profile.autoRepair and CanMerchantRepair()) then
         local repCost, _ = GetRepairAllCost();
 
         if(repCost <= GetMoney() and repCost > 0) then

--- a/modules/misc/autosell.lua
+++ b/modules/misc/autosell.lua
@@ -23,7 +23,7 @@ local GetCoinTextureString = GetCoinTextureString;
 ]]
 function ImpUI_Sell:MERCHANT_SHOW()
     -- If disabled in Config do nothing.
-    if (ImpUI.db.char.autoSell == false) then return; end
+    if (ImpUI.db.profile.autoSell == false) then return; end
     
     local copper = 0;
 

--- a/modules/misc/chat.lua
+++ b/modules/misc/chat.lua
@@ -186,9 +186,9 @@ end
     @ return void
 ]]
 function ImpUI_Chat:StyleChat()
-    if (ImpUI.db.char.styleChat == false) then return; end
+    if (ImpUI.db.profile.styleChat == false) then return; end
 
-    local chatFont = LSM:Fetch('font', ImpUI.db.char.chatFont);
+    local chatFont = LSM:Fetch('font', ImpUI.db.profile.chatFont);
 
     -- Change Edit Box Font
     ChatFontNormal:SetFont(chatFont, 12, 'THINOUTLINE');
@@ -255,7 +255,7 @@ function ImpUI_Chat:StyleChat()
         end
 
         -- Change Chat Font
-        if (ImpUI.db.char.outlineChat) then
+        if (ImpUI.db.profile.outlineChat) then
             _G[window]:SetFont(chatFont, size, 'OUTLINE');
         else
             _G[window]:SetFont(chatFont, size);
@@ -297,7 +297,7 @@ end
     @ return void
 ]]
 function ImpUI_Chat:OnEnable()
-    local minify = ImpUI.db.char.minifyStrings;
+    local minify = ImpUI.db.profile.minifyStrings;
     if (minify == true) then
         ImpUI_Chat:OverrideStrings();    
     end

--- a/modules/misc/fonts.lua
+++ b/modules/misc/fonts.lua
@@ -35,7 +35,7 @@ end
     @ return void
 ]]
 local function UpdateFonts()
-    local primaryFont = LSM:Fetch('font', ImpUI.db.char.primaryInterfaceFont);
+    local primaryFont = LSM:Fetch('font', ImpUI.db.profile.primaryInterfaceFont);
 
     UNIT_NAME_FONT     = primaryFont;
 	DAMAGE_TEXT_FONT   = primaryFont;
@@ -129,7 +129,7 @@ function ImpUI_Fonts:PrimaryFontUpdated()
 
     ImpUI:Print(warning);
 
-    OSD:AddMessage( warning, ImpUI.db.char.primaryInterfaceFont, 22, 1, 1, 0, 5.0 );
+    OSD:AddMessage( warning, ImpUI.db.profile.primaryInterfaceFont, 22, 1, 1, 0, 5.0 );
 
     UpdateFonts();
 end

--- a/modules/misc/killfeed.lua
+++ b/modules/misc/killfeed.lua
@@ -87,7 +87,7 @@ function ImpUI:UpdateKillFeed(sourceGUID, sourceName, destGUID, destName, spellN
         killfeed.recentKills[i] = killfeed.recentKills[i - 1];
     end
 
-    local showSpell = ImpUI.db.char.killFeedShowSpell;
+    local showSpell = ImpUI.db.profile.killFeedShowSpell;
 
     if (showSpell and spellName ~= nil) then
         spellString = format(' %s |cff69CCF0%s|r', L['with'], spellName);
@@ -95,7 +95,7 @@ function ImpUI:UpdateKillFeed(sourceGUID, sourceName, destGUID, destName, spellN
         spellString = format(' %s |cff69CCF0%s|r', L['with'], L['Melee']);
     end
 
-    local showDamage = ImpUI.db.char.killFeedShowDamage;
+    local showDamage = ImpUI.db.profile.killFeedShowDamage;
 
     if (showDamage and amount ~= nil) then
         damageString = format(' (%s)', Helpers.format_num(amount));
@@ -123,7 +123,7 @@ function ImpUI:UpdateKillFeed(sourceGUID, sourceName, destGUID, destName, spellN
 
     -- Set Fade Timer
     fadeTimer = C_Timer.NewTimer(7.5, function()
-        local inactiveFade = ImpUI.db.char.killFeedFadeInactive;
+        local inactiveFade = ImpUI.db.profile.killFeedFadeInactive;
         if (inactiveFade) then
             killfeed.fadeOutAnim:Play();
         end
@@ -139,15 +139,15 @@ function ImpUI_Killfeed:COMBAT_LOG_EVENT_UNFILTERED()
     local _, instanceType = IsInInstance();
 
     -- Bail out based on config options
-    if (ImpUI.db.char.killFeed == false) then return; end
+    if (ImpUI.db.profile.killFeed == false) then return; end
 
     local shouldShow = false;
 
     -- Figure out if we should show based on config.
-    if (instanceType == 'none' and ImpUI.db.char.killFeedInWorld) then shouldShow = true; end
-    if (instanceType == 'party' and ImpUI.db.char.killFeedInInstance) then shouldShow = true; end
-    if (instanceType == 'raid' and ImpUI.db.char.killFeedInRaid) then shouldShow = true; end
-    if((instanceType == 'pvp' or instanceType == 'arena' or (instanceType == 'none' and GetZonePVPInfo() == 'combat')) and ImpUI.db.char.killFeedInPvP) then shouldShow = true; end
+    if (instanceType == 'none' and ImpUI.db.profile.killFeedInWorld) then shouldShow = true; end
+    if (instanceType == 'party' and ImpUI.db.profile.killFeedInInstance) then shouldShow = true; end
+    if (instanceType == 'raid' and ImpUI.db.profile.killFeedInRaid) then shouldShow = true; end
+    if((instanceType == 'pvp' or instanceType == 'arena' or (instanceType == 'none' and GetZonePVPInfo() == 'combat')) and ImpUI.db.profile.killFeedInPvP) then shouldShow = true; end
 
     -- Bail out if it shouldn't be shown in current context.
     if (shouldShow == false) then return; end
@@ -192,9 +192,9 @@ end
     @ return void
 ]]
 function ImpUI_Killfeed:StyleKillFeed()
-    local font = ImpUI.db.char.killFeedFont;
-    local size = ImpUI.db.char.killFeedSize;
-    local spacing = ImpUI.db.char.killFeedSpacing;
+    local font = ImpUI.db.profile.killFeedFont;
+    local size = ImpUI.db.profile.killFeedSize;
+    local spacing = ImpUI.db.profile.killFeedSpacing;
 
     for i = 1, #killfeed.recentKills do
         killfeed.texts[i]:SetFont( LSM:Fetch('font', font), size, 'OUTLINE' );
@@ -215,7 +215,7 @@ end
     @ return void
 ]]
 function ImpUI_Killfeed:LoadPosition()
-    dragFrame:SetPoint(ImpUI.db.char.killFeedPosition.point, ImpUI.db.char.killFeedPosition.relativeTo, ImpUI.db.char.killFeedPosition.relativePoint, ImpUI.db.char.killFeedPosition.x, ImpUI.db.char.killFeedPosition.y);
+    dragFrame:SetPoint(ImpUI.db.profile.killFeedPosition.point, ImpUI.db.profile.killFeedPosition.relativeTo, ImpUI.db.profile.killFeedPosition.relativePoint, ImpUI.db.profile.killFeedPosition.x, ImpUI.db.profile.killFeedPosition.y);
 end
 
 -- Called when unlocking the UI.
@@ -233,7 +233,7 @@ function ImpUI_Killfeed:Lock()
     local point, relativeTo, relativePoint, xOfs, yOfs = dragFrame:GetPoint();
 
     -- Store Position
-    ImpUI.db.char.killFeedPosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
+    ImpUI.db.profile.killFeedPosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
 
     killfeed:SetParent(UIParent);
 

--- a/modules/misc/osd.lua
+++ b/modules/misc/osd.lua
@@ -59,7 +59,7 @@ function ImpUI_OSD:Lock()
     local point, relativeTo, relativePoint, xOfs, yOfs = dragFrame:GetPoint();
 
     -- Store Position
-    ImpUI.db.char.osdPosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
+    ImpUI.db.profile.osdPosition = Helpers.pack_position(point, relativeTo, relativePoint, xOfs, yOfs);
 
     osd:SetParent(UIParent);
 
@@ -72,7 +72,7 @@ end
 	Loads the position of the OSD from SavedVariables.
 ]]
 function ImpUI_OSD:LoadPosition()
-    dragFrame:SetPoint(ImpUI.db.char.osdPosition.point, ImpUI.db.char.osdPosition.relativeTo, ImpUI.db.char.osdPosition.relativePoint, ImpUI.db.char.osdPosition.x, ImpUI.db.char.osdPosition.y);
+    dragFrame:SetPoint(ImpUI.db.profile.osdPosition.point, ImpUI.db.profile.osdPosition.relativeTo, ImpUI.db.profile.osdPosition.relativePoint, ImpUI.db.profile.osdPosition.x, ImpUI.db.profile.osdPosition.y);
 end
 
 --[[

--- a/modules/misc/performance.lua
+++ b/modules/misc/performance.lua
@@ -14,7 +14,7 @@ local performance;
 
 function ImpUI_Performance:Tick()
     -- Bail out if configuration option is disabled.
-    if (ImpUI.db.char.performanceFrame == false) then
+    if (ImpUI.db.profile.performanceFrame == false) then
         performance.text:SetText(' ');
         return;
     end
@@ -60,8 +60,8 @@ end
     @ return void
 ]]
 function ImpUI_Performance:StylePerformanceFrame()
-    local font = ImpUI.db.char.primaryInterfaceFont;
-    local size = ImpUI.db.char.performanceFrameSize;
+    local font = ImpUI.db.profile.primaryInterfaceFont;
+    local size = ImpUI.db.profile.performanceFrameSize;
 
     performance.text:SetFont(LSM:Fetch('font', font), size, 'THINOUTLINE');
 end

--- a/modules/misc/tooltips.lua
+++ b/modules/misc/tooltips.lua
@@ -68,7 +68,7 @@ end
 ]]
 function ImpUI_Tooltips:ResetStyle()
     -- Bail out on config 
-    if (ImpUI.db.char.styleTooltips == true) then return; end
+    if (ImpUI.db.profile.styleTooltips == true) then return; end
 
     GameTooltipStatusBar:SetHeight(8);
     GameTooltipStatusBar:SetStatusBarTexture('Interface\\TargetingFrame\\UI-TargetingFrame-BarFill');
@@ -85,7 +85,7 @@ end
 ]]
 function ImpUI_Tooltips:StyleNormalTooltip(tip)
     -- Bail out on config 
-    if (ImpUI.db.char.styleTooltips == false) then return; end
+    if (ImpUI.db.profile.styleTooltips == false) then return; end
 
     -- Check for forbidden tooltip.
     if (tip:IsForbidden()) then return end
@@ -148,7 +148,7 @@ function ImpUI_Tooltips:StyleNormalTooltip(tip)
     tip:SetBackdropColor(backgroundColour.r, backgroundColour.g, backgroundColour.b);
 
     -- Hostility Border
-    if (ImpUI.db.char.tooltipHostileBorder) then
+    if (ImpUI.db.profile.tooltipHostileBorder) then
         tip:SetBackdropBorderColor(friendColor.r, friendColor.g, friendColor.b);
     else
         tip:SetBackdropBorderColor(borderColour.r, borderColour.g, borderColour.b);
@@ -160,14 +160,14 @@ function ImpUI_Tooltips:StyleNormalTooltip(tip)
 
     if (UnitIsPlayer(unit)) then
         -- Class Coloured
-        if (ImpUI.db.char.tooltipNameClassColours) then
+        if (ImpUI.db.profile.tooltipNameClassColours) then
             GameTooltipTextLeft1:SetFormattedText('|cff%s%s|r %s', Helpers.RGBPercToHex(Helpers.GetClassColour(unit)), UnitName(unit), AFKStatus(unit));
         else
             GameTooltipTextLeft1:SetFormattedText('%s%s', UnitName(unit), AFKStatus(unit));
         end
         
         if (guild) then
-            GameTooltipTextLeft2:SetFormattedText('|cff%s%s|r', Helpers.RGBPercToHex(ImpUI.db.char.tooltipGuildColour), guild);
+            GameTooltipTextLeft2:SetFormattedText('|cff%s%s|r', Helpers.RGBPercToHex(ImpUI.db.profile.tooltipGuildColour), guild);
             GameTooltipTextLeft3:SetFormattedText('|cff%s%s|r |cff%s%s|r', Helpers.RGBPercToHex(levelColor), level, Helpers.RGBPercToHex(friendColor), race);
         else
             GameTooltip:AddLine('', 1, 1, 1);
@@ -202,7 +202,7 @@ function ImpUI_Tooltips:StyleNormalTooltip(tip)
     end
 
     -- Target of Target
-    if (UnitExists(target) and ImpUI.db.char.tooltipToT) then
+    if (UnitExists(target) and ImpUI.db.profile.tooltipToT) then
         local name, _ = UnitName(target);
         local colour = Helpers.GetClassColour(target);
 
@@ -225,7 +225,7 @@ function ImpUI_Tooltips:StyleNormalTooltip(tip)
 	GameTooltipStatusBar:SetHeight(5);
     GameTooltipStatusBar:SetStatusBarTexture('Interface\\TargetingFrame\\UI-StatusBar');
 
-    if (ImpUI.db.char.tooltipHealthClassColours) then
+    if (ImpUI.db.profile.tooltipHealthClassColours) then
         Helpers.ApplyClassColours(GameTooltipStatusBar, unit);
     end
 end
@@ -237,8 +237,8 @@ end
 ]]
 function ImpUI_Tooltips:StyleItemTooltip(tip)
     -- Bail out on config 
-    if (ImpUI.db.char.styleTooltips == false) then return; end
-    if (ImpUI.db.char.tooltipItemRarity == false) then return; end
+    if (ImpUI.db.profile.styleTooltips == false) then return; end
+    if (ImpUI.db.profile.tooltipItemRarity == false) then return; end
 
     local _, item = tip:GetItem();
 
@@ -257,7 +257,7 @@ end
     @ return void
 ]]
 function ImpUI_Tooltips:AnchorTooltip(tip, parent)
-    if (ImpUI.db.char.anchorMouse) then
+    if (ImpUI.db.profile.anchorMouse) then
         tip:SetOwner(parent, 'ANCHOR_CURSOR');
     end
 end


### PR DESCRIPTION
Instead of settings getting saved per character, they are now saved to the active profile which can be used by multiple characters. There's a new tab in the configuration window for managing profiles. Also, added a function for reloading all modules that gets called on profile changes. This was necessary to cause the newly active configuration to actually be reflected in the UI, such as the location of unit frames.